### PR TITLE
fix: yum update during image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.vendor="Adfinis"
 
 COPY backup.sh /usr/local/bin/backup.sh
 
+RUN microdnf update -y && rm -rf /var/cache/yum
 RUN microdnf install findutils -y && microdnf clean all
 
 CMD ["/usr/local/bin/backup.sh"]


### PR DESCRIPTION
Run yum update as show in [the ubi8 docs](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/adding-software-to-a-running-ubi-container_building-running-and-managing-containers#building-an-ubi-based-image_adding-software-to-a-running-ubi-container).

This will (hopefully) get rid of the vuln warnings on artifacthub, we should also automate tagging a new release (or creatig a PR) if vulns that meet a threshold show up on nightly ci runs. We could probably do vuln scanning directly in the action and use it on pr as well.

For now, if we need to trigger an updated version to `yum update`, the way to go is to manually create a new patch release via the GitHub user interface.