### PR TITLE
Switch to floating 8.4 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.4-205@sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f
+FROM registry.access.redhat.com/ubi8-minimal:8.4@sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"


### PR DESCRIPTION
We're performing this change, because otherwise dependabot won't pick up newer releases (e.g. 8.4-205.1626828526) as an upgrade.

By using the floating tag dependabot should realize that there is a mismatch in the digest (sha256:...) and update it.