### PR TITLE
Add startingDeadlineSeconds to cronjob

### DIFF
--- a/backup-cronjob.yaml
+++ b/backup-cronjob.yaml
@@ -4,6 +4,7 @@ metadata:
   name: etcd-backup
 spec:
   schedule: "0 0 * * *"
+  startingDeadlineSeconds: 600
   jobTemplate:
     spec:
       backoffLimit: 0


### PR DESCRIPTION
For every CronJob, the CronJob Controller checks how many schedules it missed in the duration from its last scheduled time until now. If there are more than 100 missed schedules, then it does not start the job and logs the error. If the value is set, the cronjob will survive a cluster downtime.

See: https://access.redhat.com/solutions/3667021 and https://github.com/kubernetes/kubernetes/issues/42649 for details