### PR TITLE
feat: Update ubi8-minimal baseimage from 8.4 to 8.5-230

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.4@sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f
+FROM registry.access.redhat.com/ubi8-minimal:8.5-230
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"


### PR DESCRIPTION
Dependabot fails to update the image if it contains a shasum (i think the shasum was cargo culted from how it worked with renovate).

With this change we reference a proper `major.minor-build` version that can then be updated by dependabot. When Red Hat updates their ubi8-minimal images they will either release a new build version or a minor version and dependabot knows how to handle those.